### PR TITLE
Reflect API change

### DIFF
--- a/src/components/contact.js
+++ b/src/components/contact.js
@@ -135,7 +135,7 @@ const ContactFormWrapper = withFormik({
 
   handleSubmit: (values, { setSubmitting }) => {
     var success = true;
-    var url = 'https://app.airfield37.hasura-app.io/contact';
+    var url = 'https://sendgrid-mailer-api.herokuapp.com/contact';
     var formData = new FormData();
     formData.append("name", values.name);
     formData.append("email", values.email);


### PR DESCRIPTION
Due to Hasura shutting down it's free tier clusters, the API had to be hosted on Heroku. And the same is reflected in the website's contact form in this PR.

Fixes #1 